### PR TITLE
Color manager working (filtering still needs to be done)

### DIFF
--- a/src/academiccalendar/database/DBHandler.java
+++ b/src/academiccalendar/database/DBHandler.java
@@ -39,6 +39,7 @@ public class DBHandler {
                                     "FA 1st Half", "FA 2nd Half", "SP 1st Half", "SP 2nd Half",
                                     "Campus General", "Campus STC", "Campus BV",
                                     "Holiday"};
+    
     private static String defaultColor = "#000000";  //black is the default color
     
     //Variable that controls whether or not the tables have to be created and populated
@@ -172,7 +173,7 @@ public class DBHandler {
         } finally {
         }
     }
-    
+        
     //**************************  RULES Table  ***********************************************
     //Function that creates RULES Table
     void createRulesTable(){
@@ -658,6 +659,19 @@ public class DBHandler {
         
         
         return termColor;
+    }
+    
+    public void setTermColor(String term, String termRGB){
+     
+        String setTermColorAction = "UPDATE TERMS "
+                        + "SET TermColor ='" + termRGB + "' "
+                        + "WHERE TERMS.TermName LIKE " 
+                        + "'%" + term + "%'";
+        
+        System.out.println("Query to get related terms is: " + setTermColorAction);
+        
+        executeAction(setTermColorAction);
+    
     }
     
 }

--- a/src/academiccalendar/ui/main/FXMLDocumentController.java
+++ b/src/academiccalendar/ui/main/FXMLDocumentController.java
@@ -67,6 +67,7 @@ import javafx.scene.layout.RowConstraints;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -107,6 +108,7 @@ public class FXMLDocumentController implements Initializable {
     DBHandler databaseHandler;
     @FXML
     private VBox colorRootPane;
+    // Color pickers
     @FXML
     private JFXColorPicker springSemCP;
     @FXML
@@ -514,6 +516,20 @@ public class FXMLDocumentController implements Initializable {
                         
                     });
                     
+                    // Get term color from term's table
+                    String eventRGB = databaseHandler.getTermColor(termID);
+                    
+                    // Parse for rgb values
+                    String[] colors = eventRGB.split("-");
+                    String red = colors[0];
+                    String green = colors[1];
+                    String blue = colors[2];
+                    
+                    System.out.println("Color; " + red + green + blue);
+                                      
+                    eventLbl.setStyle("-fx-background-color: rgb(" + red+ 
+                            ", " + green + ", " + blue + ", " + 1 + ");");
+                    
                     // Stretch to fill box
                     eventLbl.setMaxWidth(Double.MAX_VALUE);
                     
@@ -762,9 +778,46 @@ public class FXMLDocumentController implements Initializable {
             e.printStackTrace();
          }  
        }
+   
+    private String getRGB(Color c){
+        
+        String rgb = Integer.toString((int)(c.getRed() * 255)) + "-"
+                + Integer.toString((int)(c.getGreen() * 255)) + "-"
+                + Integer.toString((int)(c.getBlue() * 255));
+        
+        return rgb;       
+    }
     
     private void changeColors(){
         // Purpose - Update colors in database and calendar from color picker
+        
+        Color springSemColor = springSemCP.getValue();
+        String springSemRGB = getRGB(springSemColor);
+        databaseHandler.setTermColor("SP SEM", springSemRGB);
+        
+        Color fallSemColor = fallSemCP.getValue();
+        String fallSemRGB = getRGB(fallSemColor);
+        databaseHandler.setTermColor("FA SEM", fallSemRGB);
+        
+        Color allQtrColor = allQtrCP.getValue();
+        String allQtrRGB = getRGB(allQtrColor);
+        databaseHandler.setTermColor("QTR", allQtrRGB);
+        
+        Color allMbaColor = allMbaCP.getValue();
+        String allMbaRGB = getRGB(allMbaColor);
+        databaseHandler.setTermColor("MBA", allMbaRGB);
+        
+        Color allHalfColor = allHalfCP.getValue();
+        String allHalfRGB = getRGB(allHalfColor);
+        databaseHandler.setTermColor("Half", allHalfRGB);
+        
+        Color allCampusColor = allCampusCP.getValue();
+        String allCampusRGB = getRGB(allCampusColor);
+        databaseHandler.setTermColor("Campus", allCampusRGB);
+        
+        Color allHolidayColor = allHolidayCP.getValue();
+        String allHolidayRGB = getRGB(allHolidayColor);
+        databaseHandler.setTermColor("Holiday", allHolidayRGB);
         
     }
    

--- a/src/academiccalendar/ui/style/mainStyle.css
+++ b/src/academiccalendar/ui/style/mainStyle.css
@@ -5,10 +5,11 @@
     -fx-border-width:1.5;
     -fx-padding: 2px;
     -fx-border-radius: 4px;
+    -fx-background-radius: 4px;
     -fx-border-color: #333;
     -fx-padding: 2px;
-    -fx-border-insets: 2px;
     -fx-text-fill: black;
+    -fx-background-insets: 2px;
 }
 
 .month-label { 


### PR DESCRIPTION
Rodolfo - Just test it and see if you can find bugs. Still working on the two problems I mentioned.

The RGB is being stored in this format: "255-255-255"
Sometimes it will look like "68-90-90" depending on the colors she picks.
Therefore I just split the string by "-" using split(). I can grab each integer value that way without worrying
about if it's 3 characters or 2 characters long.